### PR TITLE
fix preamp factor when oversampling / add warning when oversampling is recommended

### DIFF
--- a/skfilter/skf.Saike_Yutani_Filters.jsfx-inc
+++ b/skfilter/skf.Saike_Yutani_Filters.jsfx-inc
@@ -55,39 +55,40 @@ function cl01(v)
 
 function check_safety()
 (
+  warning = 0;
   ((filter_type == 1) || (filter_type==6)) && (oversampling == 1) ? (
     cutoff > safety_limit_ms20 ? (
-      slider_automate(cutoff = safety_limit_ms20);
-      warning = 75;
+      limited_cutoff = safety_limit_m20;
+      warning = 1;
     );
   );
 
   ((filter_type == 26) && (oversampling == 1)) ? (
     cutoff > safety_limit_pir ? (
-      slider_automate(cutoff = safety_limit_pir);
-      warning = 75;
+      limited_cutoff = safety_limit_pir;
+      warning = 1;
     );
   );
 
   (filter_type == 3) || (filter_type == 4) ?
   (
     cutoff > current_safety_moog ? (
-      slider_automate(cutoff = current_safety_moog);
-      warning = 75;
+      limited_cutoff = current_safety_moog;
+      warning = 1;
     );
   );
 
   filter_type == 10 ? (
     (cutoff > safety_limit_svf) && (oversampling == 1) ? (
-      slider_automate(cutoff = safety_limit_svf);
-      warning = 75;
+      limited_cutoff = safety_limit_svf;
+      warning = 1;
     );
   );
 
   (filter_type == 18) || (filter_type == 19) || (filter_type == 20) || (filter_type == 21) || (filter_type == 22) || (filter_type == 23) || (filter_type == 24) || (filter_type == 25) ? (
     (cutoff > safety_limit_resa) && (oversampling == 1) ? (
-      slider_automate(cutoff = safety_limit_resa);
-      warning = 75;
+      limited_cutoff = safety_limit_resa;
+      warning = 1;
     );
   );
 );

--- a/skfilter/skfilter.jsfx
+++ b/skfilter/skfilter.jsfx
@@ -107,8 +107,8 @@ oversampling > 1 ? (
   f = 0;
   loop(oversampling,
     f += 1;
-    ssl = oversampling*upsampleL.upSample(oversampling);
-    ssr = oversampling*upsampleR.upSample(oversampling);
+    ssl = oversampling*upsampleL.upSample(oversampling) * preamp;
+    ssr = oversampling*upsampleR.upSample(oversampling) * preamp;
 
     filter.processSample(filter_type);
     ssl *= inv_preamp;

--- a/skfilter/skfilter.jsfx
+++ b/skfilter/skfilter.jsfx
@@ -82,7 +82,7 @@ lmorph != morph ? (
   lmorph = morph;
 );
 
-//check_safety();
+check_safety();
 
 @sample
 
@@ -172,5 +172,12 @@ filter_type == 0 ? gfx_drawstr("2-pole linear state variable filter (12 dB/oct).
 : filter_type == 25 ? gfx_drawstr("Ladder filter")
 : filter_type == 26 ? gfx_drawstr("2-pole ladder filter with allpass filter for resonance.\nDrive this one hard.")
 : filter_type == 27 ? gfx_drawstr("2-pole SVF filter with antisaturator.\nDrive this one hard.")
-: filter_type == 28 ? gfx_drawstr("4-pole SVF filter with antisaturator.\nDrive this one hard.")
+: filter_type == 28 ? gfx_drawstr("4-pole SVF filter with antisaturator.\nDrive this one hard.");
+
+gfx_x = 5;
+gfx_y += 10;
+cutoff_hz = 0.5 * sampling_ratio * srate * exp((1.0 - clamp(min(limited_cutoff, cutoff), 0.0, 0.99)) * log(20/22050));
+
+warning_msg = warning ? "(Cutoff clamped! Increase oversampling to go to higher values)." : "";
+(cutoff_hz < 1000) ? gfx_printf("Cutoff: %d Hz %s", cutoff_hz, warning_msg) : gfx_printf("%.2f kHz %s", cutoff_hz / 1000, warning_msg);
 


### PR DESCRIPTION
I have two small suggestions:

- One fixes a small bug I noticed while looking at the warning issue. It seems that you are not multiplying the over-sampled branch by the preamp factor.
- The second is showing the Hz value in the @gfx section and a little warning when it is being clamped for safety.

Please let me know if you want any changes.