### PR TITLE
skfilter: don't stop processing too early (bugfix)

### DIFF
--- a/skfilter/skfilter.jsfx
+++ b/skfilter/skfilter.jsfx
@@ -86,7 +86,9 @@ check_safety();
 
 @sample
 
-spl0 || spl1 ? (
+processing = max(0.9 * processing, spl0 || spl1);
+
+processing ? (
 cutoff.smooth();
 resonance.smooth();
 drive.smooth();
@@ -137,6 +139,9 @@ oversampling > 1 ? (
 spl0 *= final_boost;
 spl1 *= final_boost;
 );
+
+// We need to make sure that both input and output are silent before shutting down the filter.
+processing = max(processing, spl0 || spl1);
 
 @gfx 460 60
 


### PR DESCRIPTION
Small fix to prevent clicks and pops. Stopping the processing early leads to clicks and pops in the audio

Here you can see the difference.
![image](https://github.com/tiagolr/tilr_jsfx/assets/19836026/4f737307-1a69-4b05-8f37-dd59cfbb1827)

Purple is with the fix, orange is without. The clicks at the start are because the filter has not decayed to its resting state when you stop processing. That means that next time you start processing again, the filter still has something in its memory that continues playing (and you hear a pop).

The click at the end is because the processing is terminated abruptly while the sound is still going.